### PR TITLE
Increase max scale to 4

### DIFF
--- a/lib/src/main/java/com/artifex/mupdf/mini/PageView.java
+++ b/lib/src/main/java/com/artifex/mupdf/mini/PageView.java
@@ -48,7 +48,7 @@ public class PageView extends View implements
 		pageScale = 1;
 		viewScale = 1;
 		minScale = 1;
-		maxScale = 2;
+		maxScale = 4;
 
 		linkPaint = new Paint();
 		linkPaint.setARGB(32, 0, 0, 255);


### PR DESCRIPTION
Hi, thanks for this great app!

I often use this app on my phone for documents like tickets which have a barcode or QR code. However, many documents will have only a small scannable area in a corner of the document. In practice, I've found that the limited 2x zoom scale means that the code is always too small to be scanned when the phone is in portrait mode. Page-sized documents are slightly larger in landscape mode, so I will always try scanning in landscape mode. Even so, it usually takes very steady hands to properly scan in full zoom in landscape mode.

If possible, it'd be awesome to increase the maximum zoom scale limit to make scanning documents easier!